### PR TITLE
ログインフォーム

### DIFF
--- a/src/components/header/header.module.css
+++ b/src/components/header/header.module.css
@@ -15,5 +15,5 @@
     color: #000;
     background-color: #de007a;
     border: solid 5px #c40cf2d2;
-    border-radius: 10px;
+    border-radius: 10px; /*角丸*/
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head'
 // import styles from '@/styles/Home.module.css'
-import Header from '@/components/header/Header'
+import Header from '@/components/header/header'
 
 
 export default function Home() {

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import Head from 'next/head'
+// import styles from '@/styles/Login.module.css'
+import Header from '@/components/header/header'
+import Link from 'next/link';
+
+
+export default function Form() {
+    const [email, setUserEmail] = useState('')
+    const [password, setPassword] = useState('')
+
+    const save = async (e: React.FormEvent<HTMLFormElement>) => {
+        console.log('save')
+        e.preventDefault()
+        const data = {
+            email: email,
+            password: password
+        }
+        try {
+            const res = await fetch('http://localhost:8080/login', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(data),
+            });
+
+            if (!res.ok) {
+                // サーバーからエラーレスポンスが返された場合の処理
+                console.error(`Fetch failed with status ${res.status}`);
+                // ここで必要なエラーハンドリングを行うことができます
+            } else {
+                const json = await res.json();
+                console.log(json);
+                // 成功した場合の処理をここに記述
+            }
+        } catch (error) {
+            // ネットワークエラーやその他の例外が発生した場合の処理
+            console.error('Fetch error:', error);
+        }
+    }
+
+    return (
+        <>
+            <Head>
+                <title>推しの議</title>
+                <meta name="description" content="推しの議" />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+                <link rel="icon" href="/favicon.ico" />
+            </Head>
+            <Header />
+
+            <form onSubmit={save}>
+                <div>
+                    <label htmlFor="email">メールアドレス</label>
+                    <input type="email" name="email" id="email" value={email} onChange={e => setUserEmail(e.target.value)} />
+                </div>
+                <div>
+                    <label htmlFor="password">パスワード</label>
+                    <input type="password" name="password" id="password" value={password} onChange={e => setPassword(e.target.value)} />
+                </div>
+                <button type="submit">ログイン</button>
+            </form>
+
+            <div>
+                <Link href="/signup">
+                    新規登録はこちらから
+                </Link>
+            </div>
+        </>
+    )
+}

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -10,7 +10,6 @@ export default function Form() {
     const [password, setPassword] = useState('')
 
     const save = async (e: React.FormEvent<HTMLFormElement>) => {
-        console.log('save')
         e.preventDefault()
         const data = {
             email: email,
@@ -28,7 +27,7 @@ export default function Form() {
             if (!res.ok) {
                 // サーバーからエラーレスポンスが返された場合の処理
                 console.error(`Fetch failed with status ${res.status}`);
-                // ここで必要なエラーハンドリングを行うことができます
+                alert('ログインに失敗しました')
             } else {
                 const json = await res.json();
                 console.log(json);

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import Head from 'next/head'
-// import styles from '@/styles/Login.module.css'
+import styles from '@/styles/Login.module.css'
 import Header from '@/components/header/header'
 import Link from 'next/link';
 
@@ -50,7 +50,7 @@ export default function Form() {
             </Head>
             <Header />
 
-            <form onSubmit={save}>
+            <form className={styles.form} onSubmit={save}>
                 <div>
                     <label htmlFor="email">メールアドレス</label>
                     <input type="email" name="email" id="email" value={email} onChange={e => setUserEmail(e.target.value)} />
@@ -59,14 +59,13 @@ export default function Form() {
                     <label htmlFor="password">パスワード</label>
                     <input type="password" name="password" id="password" value={password} onChange={e => setPassword(e.target.value)} />
                 </div>
-                <button type="submit">ログイン</button>
+                <button className={styles.login_button} type="submit">ログイン</button>
+                <div className={styles.registore}>
+                    <Link href="/signup">
+                        新規登録はこちらから
+                    </Link>
+                </div>
             </form>
-
-            <div>
-                <Link href="/signup">
-                    新規登録はこちらから
-                </Link>
-            </div>
         </>
     )
 }

--- a/src/styles/Login.module.css
+++ b/src/styles/Login.module.css
@@ -1,0 +1,39 @@
+.form {
+    font-size: large;
+    background-color: rgb(243, 127, 127);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    margin-left: 20%;
+    margin-right: 20%;
+    padding: 10%;
+    border-radius: 50px; /*角丸*/
+}
+
+.form input {
+    width: 100%;
+    padding: 10px;
+    margin: 5px;
+    font-size: large;
+    border-radius: 20px; /*角丸*/
+}
+
+.login_button{
+    background-color: #4CAF50;
+    border: none; /*枠線なし*/
+    color: white;
+    padding: 15px 32px;
+    margin: 20px;
+    font-size: 16px;
+    border-radius: 10px; /*角丸*/
+}
+
+.registore{
+    background-color: #eeff00;
+    border: none; /*枠線なし*/
+    padding: 15px 32px;
+    margin: 20px;
+    font-size: 16px;
+    border-radius: 10px; /*角丸*/
+}


### PR DESCRIPTION
<img width="1680" alt="image" src="https://github.com/yuorei/oshinogi-front/assets/108039575/dada7d67-82e6-4123-bc62-c23b3dd67fc6">

`/login`　のページを作成しました。
メールアドレスとパスワードをいれてログインを押すと

```
{
  email: "email",
  password: "password"
}
```

としてバックエンドの `/login` にPOSTするようにしています。
新規登録ページへいくリンクも作成しています。