### PR TITLE
政治家個人ページの作成

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    domains: [''], // 画像ドメイン名を追加する
+  },
 }
 
 module.exports = nextConfig

--- a/src/pages/politician/[id].tsx
+++ b/src/pages/politician/[id].tsx
@@ -2,7 +2,9 @@ import Head from 'next/head'
 import Image from 'next/image'
 import { notFound } from "next/navigation";
 import styles from '@/styles/Politician.module.css'
+import styleshome from '@/styles/Home.module.css'
 import { useRouter } from 'next/router'
+import Header from '@/components/header/header'
 
 interface Post {
     id: number;
@@ -20,11 +22,11 @@ interface PoliticianInformation {
 const posts = [
     {
         id: 1,
-        post: '参議院議員の投稿',
+        post: '投稿コメント1',
     },
     {
         id: 2,
-        post: '衆議院議員の投稿',
+        post: '投稿コメント2',
     },
 ]
 
@@ -33,7 +35,7 @@ const politicianInformation = {
     name: 'やまださん',
     age: 30,
     level: 1,
-    imageURL: 'https://hackmd.io/_uploads/H1x4vLvRn.jpg',
+    imageURL: 'https://example.com/example.jpg',
 }
 
 const getPoliticianPost = async (id: number) => {
@@ -86,12 +88,13 @@ export default function Politician() {
                 <meta name="viewport" content="width=device-width, initial-scale=1" />
                 <link rel="icon" href="/favicon.ico" />
             </Head>
+            <Header />
             <div className={styles.politician_page}>
-                <div className={styles.post}>
+                <ul className={styles.posts}>
                     {posts.map((post) => (
-                        <p key={post.id} className={styles.politician_page}>{post.post}</p>
+                        <li key={post.id} className={styles.post}>{post.post}</li>
                     ))}
-                </div>
+                </ul>
                 <div>
                     <Image
                         src={politicianInformation.imageURL}
@@ -99,9 +102,9 @@ export default function Politician() {
                         width={500}
                         height={500}
                     />
-                    <p>名前: {politicianInformation.name}</p>
-                    <p>レベル: {politicianInformation.level}</p>
-                    <p>年齢: {politicianInformation.age}</p>
+                    <p className={styleshome.p}>名前: {politicianInformation.name}</p>
+                    <p className={styleshome.p}>レベル: {politicianInformation.level}</p>
+                    <p className={styleshome.p}>年齢: {politicianInformation.age}</p>
                 </div>
             </div>
         </>

--- a/src/pages/politician/[id].tsx
+++ b/src/pages/politician/[id].tsx
@@ -1,0 +1,105 @@
+import Head from 'next/head'
+import Image from 'next/image'
+import { notFound } from "next/navigation";
+import styles from '@/styles/Politician.module.css'
+import { useRouter } from 'next/router'
+
+interface Post {
+    id: number;
+    post: string;
+}
+
+interface PoliticianInformation {
+    name: string;
+    age: number;
+    level: number;
+    imageURL: string;
+}
+
+// TODO バックエンド実装後に消す
+const posts = [
+    {
+        id: 1,
+        post: '参議院議員',
+    }
+]
+
+// TODO バックエンド実装後に消す
+const politicianInformation = {
+    name: 'やまださん',
+    age: 30,
+    level: 1,
+    imageURL: 'https://hackmd.io/_uploads/H1x4vLvRn.jpg',
+}
+
+const getPoliticianPost = async (id: number) => {
+    try {
+        const res = await fetch(`http://localhost:8080/politician/post/${id}`);
+        if (res.status === 404) {
+            notFound();
+        }
+        if (!res.ok) {
+            throw new Error("Failed to fetch politician");
+        }
+        const data = await res.json();
+
+        return data as Post[];
+    } catch (error) {
+        // エラーハンドリングのコードをここに追加
+        console.error("An error occurred:", error);
+    }
+}
+
+const getPoliticianInformation = async (id: number) => {
+    try {
+        const res = await fetch(`http://localhost:8080/politician/${id}`);
+        if (res.status === 404) {
+            notFound();
+        }
+        if (!res.ok) {
+            throw new Error("Failed to fetch politician");
+        }
+        const data = await res.json();
+
+        return data as PoliticianInformation;
+    } catch (error) {
+        // エラーハンドリングのコードをここに追加
+        console.error("An error occurred:", error);
+    }
+}
+
+// TODO feachで取得したデータを表示する場合はasync awaitを使う
+export default function Politician() {
+    const router = useRouter()
+    const id = router.query.id;
+    // const posts = await getPoliticianPost(id)
+    // const politicianInformation = await getPoliticianInformation(id)
+    return (
+        <>
+            <Head>
+                <title>推しの議</title>
+                <meta name="description" content="推しの議" />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+                <link rel="icon" href="/favicon.ico" />
+            </Head>
+            <div className={styles.politician_page}>
+                <div className={styles.post}>
+                    {posts.map((post) => (
+                        <p key={post.id} className={styles.politician_page}>{post.post}</p>
+                    ))}
+                </div>
+                <div>
+                    <Image
+                        src={politicianInformation.imageURL}
+                        alt={politicianInformation.name}
+                        width={500}
+                        height={500}
+                    />
+                    <p>名前: {politicianInformation.name}</p>
+                    <p>レベル: {politicianInformation.level}</p>
+                    <p>年齢: {politicianInformation.age}</p>
+                </div>
+            </div>
+        </>
+    )
+}

--- a/src/pages/politician/[id].tsx
+++ b/src/pages/politician/[id].tsx
@@ -20,8 +20,12 @@ interface PoliticianInformation {
 const posts = [
     {
         id: 1,
-        post: '参議院議員',
-    }
+        post: '参議院議員の投稿',
+    },
+    {
+        id: 2,
+        post: '衆議院議員の投稿',
+    },
 ]
 
 // TODO バックエンド実装後に消す

--- a/src/styles/Politician.module.css
+++ b/src/styles/Politician.module.css
@@ -1,0 +1,20 @@
+.politician_page {
+    color: red;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-left: 10%;
+    margin-right: 10%;
+}
+
+.posts {
+    color: blue;
+    list-style: none;
+}
+
+.post {
+    color: rgb(44, 12, 255);
+    background-color: rgb(191, 191, 191);
+    border: 2px solid #000000;
+    font-size: 50px;
+}


### PR DESCRIPTION
<img width="1641" alt="Screenshot 2023-09-21 at 11 27 02" src="https://github.com/yuorei/oshinogi-front/assets/108039575/36769752-df2f-4391-a89b-5056259b8aaa">

`politician/1` idごとにページを分けている

政治家の情報と投稿データを取得して表示する予定。ただし現在はバックエンドが実装されていないためサンプルデータが入っている